### PR TITLE
Add user authentication and file management

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+
+from .models import Document
+
+
+class SignupForm(UserCreationForm):
+    class Meta:
+        model = User
+        fields = ("username",)
+
+
+class DocumentForm(forms.ModelForm):
+    class Meta:
+        model = Document
+        fields = ("title", "file")

--- a/files/templates/files/document_list.html
+++ b/files/templates/files/document_list.html
@@ -5,7 +5,17 @@
     <title>Documents</title>
 </head>
 <body>
+    <p>
+        Logged in as {{ user.username }} |
+        <a href="{% url 'files:logout' %}">Logout</a>
+    </p>
     <h1>Available Documents</h1>
+    {% if user.is_staff %}
+    <p>
+        <a href="{% url 'files:upload_document' %}">Upload Document</a> |
+        <a href="{% url 'files:user_list' %}">Manage Users</a>
+    </p>
+    {% endif %}
     <ul>
         {% for document in documents %}
         <li>

--- a/files/templates/files/signup.html
+++ b/files/templates/files/signup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Sign up</title>
+</head>
+<body>
+    <h1>Create account</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Sign up</button>
+    </form>
+    <p>Already have an account? <a href="{% url 'files:login' %}">Login</a></p>
+</body>
+</html>

--- a/files/templates/files/upload.html
+++ b/files/templates/files/upload.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Upload Document</title>
+</head>
+<body>
+    <h1>Upload Document</h1>
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Upload</button>
+    </form>
+    <p><a href="{% url 'files:document_list' %}">Back to documents</a></p>
+</body>
+</html>

--- a/files/templates/files/user_list.html
+++ b/files/templates/files/user_list.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>User Management</title>
+</head>
+<body>
+    <h1>Users</h1>
+    <ul>
+        {% for user in users %}
+        <li>{{ user.username }}</li>
+        {% empty %}
+        <li>No users found.</li>
+        {% endfor %}
+    </ul>
+    <p><a href="{% url 'files:document_list' %}">Back to documents</a></p>
+</body>
+</html>

--- a/files/templates/registration/login.html
+++ b/files/templates/registration/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Log in</button>
+    </form>
+    <p>Don't have an account? <a href="{% url 'files:signup' %}">Sign up</a></p>
+</body>
+</html>

--- a/files/tests.py
+++ b/files/tests.py
@@ -1,3 +1,41 @@
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Document
+
+
+class AuthTests(TestCase):
+    def test_signup_creates_user(self):
+        response = self.client.post(reverse("files:signup"), {
+            "username": "newuser",
+            "password1": "ComplexPwd123",
+            "password2": "ComplexPwd123",
+        })
+        self.assertRedirects(response, reverse("files:login"))
+        self.assertEqual(User.objects.filter(username="newuser").count(), 1)
+
+    def test_document_list_requires_login(self):
+        response = self.client.get(reverse("files:document_list"))
+        self.assertRedirects(response, "/files/login/?next=/files/")
+
+
+class UploadTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(username="staff", password="pass", is_staff=True)
+        self.user = User.objects.create_user(username="user", password="pass")
+
+    def test_staff_can_upload(self):
+        self.client.login(username="staff", password="pass")
+        upload = SimpleUploadedFile("test.txt", b"filecontent")
+        response = self.client.post(reverse("files:upload_document"), {"title": "Test", "file": upload})
+        self.assertRedirects(response, reverse("files:document_list"))
+        self.assertEqual(Document.objects.count(), 1)
+
+    def test_non_staff_cannot_upload(self):
+        self.client.login(username="user", password="pass")
+        upload = SimpleUploadedFile("test.txt", b"filecontent")
+        response = self.client.post(reverse("files:upload_document"), {"title": "Test", "file": upload})
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Document.objects.count(), 0)

--- a/files/urls.py
+++ b/files/urls.py
@@ -1,7 +1,15 @@
+from django.contrib.auth import views as auth_views
 from django.urls import path
 
 from . import views
 
+app_name = "files"
+
 urlpatterns = [
-    path('', views.document_list, name='document_list'),
+    path("login/", auth_views.LoginView.as_view(template_name="registration/login.html"), name="login"),
+    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("signup/", views.signup, name="signup"),
+    path("upload/", views.upload_document, name="upload_document"),
+    path("users/", views.user_list, name="user_list"),
+    path("", views.document_list, name="document_list"),
 ]

--- a/files/views.py
+++ b/files/views.py
@@ -1,9 +1,46 @@
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
+from django.http import HttpResponseForbidden
+from django.shortcuts import redirect, render
 
+from .forms import DocumentForm, SignupForm
 from .models import Document
 
 
+@login_required
 def document_list(request):
     documents = Document.objects.all()
     return render(request, "files/document_list.html", {"documents": documents})
 
+
+def signup(request):
+    if request.method == "POST":
+        form = SignupForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("files:login")
+    else:
+        form = SignupForm()
+    return render(request, "files/signup.html", {"form": form})
+
+
+@login_required
+def upload_document(request):
+    if not request.user.is_staff:
+        return HttpResponseForbidden()
+    if request.method == "POST":
+        form = DocumentForm(request.POST, request.FILES)
+        if form.is_valid():
+            form.save()
+            return redirect("files:document_list")
+    else:
+        form = DocumentForm()
+    return render(request, "files/upload.html", {"form": form})
+
+
+@login_required
+def user_list(request):
+    if not request.user.is_staff:
+        return HttpResponseForbidden()
+    users = User.objects.all()
+    return render(request, "files/user_list.html", {"users": users})

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -124,3 +124,7 @@ MEDIA_ROOT = BASE_DIR / 'media'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+LOGIN_URL = '/files/login/'
+LOGIN_REDIRECT_URL = '/files/'
+LOGOUT_REDIRECT_URL = '/files/login/'


### PR DESCRIPTION
## Summary
- add signup and upload forms for documents
- secure file listing behind login and provide user management for staff
- test registration flow and permission checks

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68a3e6cb86148324a4ce7e589a2c094c